### PR TITLE
createPlotWindow -> Plot

### DIFF
--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -39,7 +39,8 @@ function rebuildUnicodePlot!(plt::Plot)
 
   # create a plot window with xlim/ylim set, but the X/Y vectors are outside the bounds
   width, height = iargs[:size]
-  o = UnicodePlots.createPlotWindow(x, y; width = width,
+    o = UnicodePlots.Plot(x, y, UnicodePlots.BrailleCanvas;
+                          width = width,
                                 height = height,
                                 title = iargs[:title],
                                 # labels = iargs[:legend],


### PR DESCRIPTION
In UnicodePlots, the function `createPlotWindow` no longer exists. I think just calling `Plot` is sufficient here along with a canvas type, but am certainly no expert in the matter. This pull request does that change. It seems to work on the basic plots I tested. `Pkg.test` had issues, but the error of `QuartzImageIO` not being installed seems unrelated to this change.