### PR TITLE
don't test for 0.4-

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,7 +1,5 @@
 
-if VERSION >= v"0.4-"
-  __precompile__()
-end
+ __precompile__()
 
 module Plots
 


### PR DESCRIPTION
Testing version > 0.4- is wrong because it incorrectly implies that all pre-releases of 0.4 work.  Either test for the specific 0.4 build you need, or test for `VERSION > v"0.4"` (i.e., the release version).

However, since you REQUIRE julia 0.4 anyway, you can omit this test entirely.