### PR TITLE
Add support for levels keyword in PyPlot

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -2,8 +2,8 @@
 
 const _allAxes = [:auto, :left, :right]
 @compat const _axesAliases = Dict(
-    :a => :auto, 
-    :l => :left, 
+    :a => :auto,
+    :l => :left,
     :r => :right
   )
 
@@ -139,6 +139,7 @@ _seriesDefaults[:z]               = nothing           # depth for contour, surfa
 _seriesDefaults[:zcolor]          = nothing           # value for color scale
 # _seriesDefaults[:surface]         = nothing
 _seriesDefaults[:nlevels]         = 15
+_seriesDefaults[:levels]          = nothing
 _seriesDefaults[:orientation]     = :vertical
 
 
@@ -407,7 +408,7 @@ function processLineArg(d::Dict, arg)
   # linetype
   if trueOrAllTrue(a -> get(_typeAliases, a, a) in _allTypes, arg)
     d[:linetype] = arg
-  
+
   # linestyle
   elseif trueOrAllTrue(a -> get(_styleAliases, a, a) in _allStyles, arg)
     d[:linestyle] = arg
@@ -446,7 +447,7 @@ function processMarkerArg(d::Dict, arg)
     d[:markershape] = arg
   elseif trueOrAllTrue(a -> isa(a, Shape), arg)
     d[:markershape] = arg
-  
+
   # stroke style
   elseif trueOrAllTrue(a -> get(_styleAliases, a, a) in _allStyles, arg)
     d[:markerstrokestyle] = arg
@@ -473,7 +474,7 @@ function processMarkerArg(d::Dict, arg)
   # markercolor
   elseif !handleColors!(d, arg, :markercolor)
     warn("Skipped marker arg $arg.")
-    
+
   end
 end
 
@@ -493,7 +494,7 @@ end
 "Handle all preprocessing of args... break out colors/sizes/etc and replace aliases."
 function preprocessArgs!(d::Dict)
   replaceAliases!(d, _keyAliases)
-  
+
   # handle axis args
   for axisletter in ("x", "y")
     asym = symbol(axisletter * "axis")
@@ -590,7 +591,7 @@ end
 
 
 function warnOnUnsupported(pkg::PlottingPackage, d::Dict)
-  (d[:axis] in supportedAxes(pkg) 
+  (d[:axis] in supportedAxes(pkg)
     || warn("axis $(d[:axis]) is unsupported with $pkg.  Choose from: $(supportedAxes(pkg))"))
   (d[:linetype] == :none
     || d[:linetype] in supportedTypes(pkg)
@@ -683,7 +684,7 @@ function getSeriesArgs(pkg::PlottingPackage, plotargs::Dict, kw, commandIndex::I
       d[k] = kwdict[k]
     end
   end
-  
+
   if haskey(_typeAliases, d[:linetype])
     d[:linetype] = _typeAliases[d[:linetype]]
   end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -232,7 +232,7 @@ function _add_series(pkg::PyPlotPackage, plt::Plot; kw...)
 
   if lt == :sticks
     d,_ = sticksHack(;d...)
-  
+
   elseif lt in (:scatter, :scatter3d)
     if d[:markershape] == :none
       d[:markershape] = :ellipse
@@ -334,13 +334,20 @@ function _add_series(pkg::PyPlotPackage, plt::Plot; kw...)
   d[:serieshandle] = if ishistlike(lt)
     plotfunc(d[:y]; extra_kwargs...)[1]
   elseif lt == :contour
-    # NOTE: x/y are backwards in pyplot, so we switch the x and y args (also y is reversed), 
+    # NOTE: x/y are backwards in pyplot, so we switch the x and y args (also y is reversed),
     #       and take the transpose of the surface matrix
     x, y = d[:x], d[:y]
     surf = d[:z].surf'
-    handle = plotfunc(x, y, surf, d[:nlevels]; extra_kwargs...)
-    if d[:fillrange] != nothing
-      handle = ax[:contourf](x, y, surf, d[:nlevels]; cmap = getPyPlotColorMap(d[:fillcolor], d[:fillalpha]))
+    if d[:levels] != nothing
+        handle = plotfunc(x, y, surf; levels=d[:levels], extra_kwargs...)
+        if d[:fillrange] != nothing
+          handle = ax[:contourf](x, y, surf; levels=d[:levels], cmap = getPyPlotColorMap(d[:fillcolor], d[:fillalpha]))
+        end
+    else
+        handle = plotfunc(x, y, surf, d[:nlevels]; extra_kwargs...)
+        if d[:fillrange] != nothing
+          handle = ax[:contourf](x, y, surf, d[:nlevels]; cmap = getPyPlotColorMap(d[:fillcolor], d[:fillalpha]))
+        end
     end
     handle
   elseif lt in (:surface,:wireframe)
@@ -473,7 +480,7 @@ function _update_plot(plt::Plot{PyPlotPackage}, d::Dict)
     ax[:set_ylabel](d[:ylabel])
   end
   if usingRightAxis(plt) && get(d, :yrightlabel, "") != ""
-    rightax = getRightAxis(figorax)  
+    rightax = getRightAxis(figorax)
     rightax[:set_ylabel](d[:yrightlabel])
   end
 
@@ -502,7 +509,7 @@ function _update_plot(plt::Plot{PyPlotPackage}, d::Dict)
   # font sizes
   for ax in axes
     # haskey(d, :yrightlabel) || continue
-    
+
 
     # guides
     sz = get(d, :guidefont, plt.plotargs[:guidefont]).pointsize
@@ -517,7 +524,7 @@ function _update_plot(plt::Plot{PyPlotPackage}, d::Dict)
         lab[:set_fontsize](sz)
       end
     end
-  
+
     # grid
     if get(d, :grid, false)
       ax[:xaxis][:grid](true)

--- a/src/backends/supported.jl
+++ b/src/backends/supported.jl
@@ -155,6 +155,7 @@ supportedArgs(::PyPlotPackage) = [
     :grid,
     # :surface,
     :nlevels,
+    :levels,
     :fillalpha,
     :linealpha,
     :markeralpha,


### PR DESCRIPTION
The following now works for specifying the levels explicitly:

```julia
using Plots
x=y=0.:.1:1.
z=Float64[exp(x)*cos(y) for x=x,y=y]
plot(x,y,z;t=:contour,levels=[.6,1.5,2.6])
```

This is particularly useful for movies, where you don't want the meaning of the levels to change.

If you are happy with these changes, I can also add bins (i.e., bins/nbins mirrors levels/nlevels), and add support for Gadfly.

