### PR TITLE
fix unicodeplots compat

### DIFF
--- a/src/backends/unicodeplots.jl
+++ b/src/backends/unicodeplots.jl
@@ -91,13 +91,13 @@ function addUnicodeSeries!(o, d::Dict, addlegend::Bool, xlim, ylim)
   else
     error("Linestyle $lt not supported by UnicodePlots")
   end
-  
+
   # get the series data and label
   x, y = [collect(float(d[s])) for s in (:x, :y)]
   label = addlegend ? d[:label] : ""
 
   # if we happen to pass in allowed color symbols, great... otherwise let UnicodePlots decide
-  color = d[:linecolor] in UnicodePlots.autoColors ? d[:linecolor] : :auto
+  color = d[:linecolor] in UnicodePlots.color_cycle ? d[:linecolor] : :auto
 
   # add the series
   func(o, x, y; color = color, name = label, style = stepstyle)


### PR DESCRIPTION
Addresses https://github.com/tbreloff/Plots.jl/issues/88 but doesn't fix it completely

However, an error still remains which is the most cryptic I have ever seen in Julia.

Try executing the following code (**edit**: with this patch). It will throw an error, but just execute it again. everytime the error changes a little and after executing it 6 times it works.

```Julia
using Plots
unicodeplots()
x = linspace(0,2pi,20);
plot(x,sin(x))
```

The final error message shows the origin to be

```
....
 in typeinf at ./inference.jl:1339
 in typeinf_ext at ./inference.jl:1283
 in display at /home/csto/.julia/v0.4/Plots/src/backends/unicodeplots.jl:185
 in gui at /home/csto/.julia/v0.4/Plots/src/output.jl:110
 in display at /home/csto/.julia/v0.4/Plots/src/output.jl:114
 in display at REPL.jl:117
 [inlined code] from multimedia.jl:151
 in display at multimedia.jl:162
 in print_response at REPL.jl:134
 in print_response at REPL.jl:121
 in anonymous at REPL.jl:624
 in run_interface at ./LineEdit.jl:1610
 in run_frontend at ./REPL.jl:863
 in run_repl at ./REPL.jl:167
 in _start at ./client.jl:420
```