### PR TITLE
Add abline! which creates a straight line according to the formula b+…

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -59,6 +59,7 @@ export
   path3d!,
   scatter3d,
   scatter3d!,
+  abline!,
 
   title!,
   xlabel!,

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -132,7 +132,7 @@ end
 
 "Adds a+bx... straight line over the current plot"
 function abline!(plt::Plot, a, b; kw...)
-    plot!(plt, [xmin(plt), xmax(plt)], x -> b + a*x; kw...)
+    plot!(plt, [extrema(plt)...], x -> b + a*x; kw...)
 end
 
 abline!(args...; kw...) = abline!(current(), args...; kw...)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -130,3 +130,9 @@ function spy{T<:Real}(y::AMat{T}; kw...)
   heatmap(J, I; leg=false, yflip=true, nbins=size(y), kw...)
 end
 
+"Adds a+bx... straight line over the current plot"
+function abline!(plt::Plot, a, b; kw...)
+    plot!(plt, [xmin(plt), xmax(plt)], x -> b + a*x; kw...)
+end
+
+abline!(args...; kw...) = abline!(current(), args...; kw...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -471,3 +471,5 @@ xmin(plt::Plot) = minimum([minimum(d[:x]) for d in plt.seriesargs])
 "Largest x in plot"
 xmax(plt::Plot) = maximum([maximum(d[:x]) for d in plt.seriesargs])
 
+"Extrema of x-values in plot"
+Base.extrema(plt::Plot) = (xmin(plt), xmax(plt))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -465,3 +465,9 @@ mm2inch(mm::Real) = float(mm / MM_PER_INCH)
 px2mm(px::Real) = float(px * MM_PER_PX)
 mm2px(mm::Real) = float(px / MM_PER_PX)
 
+
+"Smallest x in plot"
+xmin(plt::Plot) = minimum([minimum(d[:x]) for d in plt.seriesargs])
+"Largest x in plot"
+xmax(plt::Plot) = maximum([maximum(d[:x]) for d in plt.seriesargs])
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -246,7 +246,7 @@ function with(f::Function, args...; kw...)
   oldbackend = CURRENT_BACKEND.sym
 
   for arg in args
-    
+
     # change backend?
     if arg in backends()
       backend(arg)
@@ -421,10 +421,10 @@ function supportGraph(allvals, func)
             push!(x, string(b))
             push!(y, string(val))
         end
-      end 
+      end
   end
   n = length(vals)
-  
+
   scatter(x,y,
           m=:rect,
           ms=10,


### PR DESCRIPTION
…a*x.

Implements #125 . The syntax matches with the name such that `abline!(a, b)` adds a straight line `b+a*x` based on only x-min and x-max.

Does it match with your usual style of coding @tbreloff or are there any changes you would like?