### PR TITLE
Better handling of xlims in Gadfly

### DIFF
--- a/src/backends/gadfly.jl
+++ b/src/backends/gadfly.jl
@@ -355,18 +355,18 @@ function getGadflyScaleFunction(d::KW, isx::Bool)
     hasScaleKey = haskey(d, scalekey)
     if hasScaleKey
         scale = d[scalekey]
-        scale == :ln && return isx ? Gadfly.Scale.x_log : Gadfly.Scale.y_log, hasScaleKey
-        scale == :log2 && return isx ? Gadfly.Scale.x_log2 : Gadfly.Scale.y_log2, hasScaleKey
-        scale == :log10 && return isx ? Gadfly.Scale.x_log10 : Gadfly.Scale.y_log10, hasScaleKey
-        scale == :asinh && return isx ? Gadfly.Scale.x_asinh : Gadfly.Scale.y_asinh, hasScaleKey
-        scale == :sqrt && return isx ? Gadfly.Scale.x_sqrt : Gadfly.Scale.y_sqrt, hasScaleKey
+        scale == :ln && return isx ? Gadfly.Scale.x_log : Gadfly.Scale.y_log, hasScaleKey, exp
+        scale == :log2 && return isx ? Gadfly.Scale.x_log2 : Gadfly.Scale.y_log2, hasScaleKey, exp2
+        scale == :log10 && return isx ? Gadfly.Scale.x_log10 : Gadfly.Scale.y_log10, hasScaleKey, exp10
+        scale == :asinh && return isx ? Gadfly.Scale.x_asinh : Gadfly.Scale.y_asinh, hasScaleKey, sinh
+        scale == :sqrt && return isx ? Gadfly.Scale.x_sqrt : Gadfly.Scale.y_sqrt, hasScaleKey, x -> x*x
     end
-    isx ? Gadfly.Scale.x_continuous : Gadfly.Scale.y_continuous, hasScaleKey
+    isx ? Gadfly.Scale.x_continuous : Gadfly.Scale.y_continuous, hasScaleKey, identity
 end
 
 
 function addGadflyLimitsScale(gplt, d::KW, isx::Bool)
-    gfunc, hasScaleKey = getGadflyScaleFunction(d, isx)
+    gfunc, hasScaleKey, inverse = getGadflyScaleFunction(d, isx)
 
     # do we want to add min/max limits for the axis?
     limsym = isx ? :xlims : :ylims
@@ -378,8 +378,8 @@ function addGadflyLimitsScale(gplt, d::KW, isx::Bool)
         lims = nothing
     else
         if limsType(lims) == :limits
-            push!(limargs, (:minvalue, min(lims...)))
-            push!(limargs, (:maxvalue, max(lims...)))
+            push!(limargs, (:minvalue, inverse(min(lims...))))
+            push!(limargs, (:maxvalue, inverse(max(lims...))))
         else
             error("Invalid input for $(isx ? "xlims" : "ylims"): ", lims)
         end

--- a/src/backends/gadfly.jl
+++ b/src/backends/gadfly.jl
@@ -432,8 +432,8 @@ function updateGadflyGuides(plt::Plot, d::KW)
     haskey(d, :xlabel) && findGuideAndSet(gplt, Gadfly.Guide.xlabel, string(d[:xlabel]))
     haskey(d, :ylabel) && findGuideAndSet(gplt, Gadfly.Guide.ylabel, string(d[:ylabel]))
 
-    xlims = addGadflyLimitsScale(gplt, d, true)
-    ylims = addGadflyLimitsScale(gplt, d, false)
+    xlims, xfunc = addGadflyLimitsScale(gplt, d, true)
+    ylims, yfunc = addGadflyLimitsScale(gplt, d, false)
 
     ticks = get(d, :xticks, :auto)
     if ticks == :none
@@ -448,7 +448,7 @@ function updateGadflyGuides(plt::Plot, d::KW)
         addGadflyTicksGuide(gplt, ticks, false)
     end
 
-    updateGadflyAxisFlips(gplt, d, xlims, ylims)
+    updateGadflyAxisFlips(gplt, d, xlims, ylims, xfunc, yfunc)
 end
 
 function updateGadflyPlotTheme(plt::Plot, d::KW)


### PR DESCRIPTION
This should solve the problem in issue #177.
You should however be aware that the values ymin/ymax in Gadfly.Scale.ContinuousScale is handled differently than in Gadfly.Coord.Cartesian which is what caused this bug in the first place.

One problem that persists is that while the values in ContinuousScale can extend the range of values shown, it can't decrease it to hide parts of the plot. This might make the axes change the first time an update is made (the behavior is the same without this patch).