### PR TITLE
Add aspect_ratio to PGFPlots backend.

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -2,6 +2,7 @@
 
 supportedArgs(::PGFPlotsBackend) = [
     # :annotation,
+     :aspect_ratio,
     # :axis,
      :background_color,
     # :color_palette,
@@ -319,11 +320,14 @@ function _pgfplots_get_axis_kwargs(d)
         axisargs[:ymax] = d[:ylims][2]
     end
     if d[:grid] == true
-        axisargs[:style] *= "grid = major"
+        axisargs[:style] *= "grid = major,"
     elseif d[:grid] == false
 
     end
 
+    if d[:aspect_ratio] == :equal
+        axisargs[:axisEqual] = "true"
+    end
     axisargs
 end
 


### PR DESCRIPTION
This adds the possibility of using `aspect_ratio = :equal` to pgfplots plots.

Is the aspect ratio going to be `:equal` or `1` if it is set to `:equal` by the user, @tbreloff  ? It can wait until the pyplot branch merges if you're not done working out the specifics...