### PR TITLE
gr: support for colormaps

### DIFF
--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -427,6 +427,17 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
 
   for p in plt.seriesargs
     lt = p[:linetype]
+    if lt in (:hist2d, :hexbin, :contour, :surface, :wireframe, :heatmap)
+      if haskey(d, :color_palette)
+        ci = 1000
+        for cv in d[:color_palette]
+          GR.setcolorrep(ci, cv.r, cv.g, cv.b)
+          ci += 1
+        end
+      else
+        GR.setcolormap(GR.COLORMAP_COOLWARM)
+      end
+    end
     if get(d, :polar, false)
       lt = :polar
     end
@@ -554,7 +565,6 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
       x, y, H = Base.hist2d(E, xbins, ybins)
       counts = round(Int32, 1000 + 255 * H / maximum(H))
       n, m = size(counts)
-      GR.setcolormap(GR.COLORMAP_COOLWARM)
       GR.cellarray(xmin, xmax, ymin, ymax, n, m, counts)
       GR.setviewport(viewport[2] + 0.02, viewport[2] + 0.05,
                      viewport[3], viewport[4])
@@ -573,7 +583,6 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
       else
         h = linspace(zmin, zmax, p[:levels])
       end
-      GR.setcolormap(GR.COLORMAP_COOLWARM)
       GR.contour(x, y, h, reshape(z, length(x) * length(y)), 1000)
       GR.setviewport(viewport[2] + 0.02, viewport[2] + 0.05,
                      viewport[3], viewport[4])
@@ -602,7 +611,6 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
       end
       z = reshape(z, length(x) * length(y))
       if lt == :surface
-        GR.setcolormap(GR.COLORMAP_COOLWARM)
         GR.gr3.surface(x, y, z, GR.OPTION_COLORED_MESH)
       else
         GR.setfillcolorind(0)
@@ -621,7 +629,6 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
       x, y, z = p[:x], p[:y], transpose_z(p, p[:z].surf, false)
       zmin, zmax = gr_getzlims(d, minimum(z), maximum(z), true)
       GR.setspace(zmin, zmax, 0, 90)
-      GR.setcolormap(GR.COLORMAP_COOLWARM)
       z = reshape(z, length(x) * length(y))
       GR.surface(x, y, z, GR.OPTION_CELL_ARRAY)
       if cmap

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -260,7 +260,11 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
         elseif lt == :ohlc
           x, y = 1:size(p[:y], 1), p[:y]
         elseif lt in [:hist, :density]
-          x, y = Base.hist(p[:y])
+          if haskey(p, :bins)
+            x, y = Base.hist(p[:y], p[:bins])
+          else
+            x, y = Base.hist(p[:y])
+          end
         elseif lt in [:hist2d, :hexbin]
           E = zeros(length(p[:x]),2)
           E[:,1] = p[:x]
@@ -516,7 +520,11 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
         GR.fillrect(i-0.4, i+0.4, max(0, ymin), y[i])
       end
     elseif lt in [:hist, :density]
-      h = Base.hist(p[:y])
+      if haskey(p, :bins)
+        h = Base.hist(p[:y], p[:bins])
+      else
+        h = Base.hist(p[:y])
+      end
       x, y = float(collect(h[1])), float(h[2])
       for i = 2:length(y)
         GR.setfillcolorind(gr_getcolorind(p[:fillcolor]))

--- a/src/backends/gr.jl
+++ b/src/backends/gr.jl
@@ -135,6 +135,7 @@ end
 
 function gr_polaraxes(rmin, rmax)
   GR.savestate()
+  GR.setlinetype(GR.LINETYPE_SOLID)
   GR.setlinecolorind(88)
   tick = 0.5 * GR.tick(rmin, rmax)
   n = round(Int, (rmax - rmin) / tick + 0.5)
@@ -147,9 +148,10 @@ function gr_polaraxes(rmin, rmax)
       end
       GR.settextalign(GR.TEXT_HALIGN_LEFT, GR.TEXT_VALIGN_HALF)
       x, y = GR.wctondc(0.05, r)
-      GR.text(x, y, @sprintf("%g", rmin + i * tick))
+      GR.text(x, y, string(signif(rmin + i * tick, 12)))
     else
       GR.setlinecolorind(90)
+      GR.drawarc(-r, r, -r, r, 0, 359)
     end
   end
   for alpha in 0:45:315
@@ -695,7 +697,7 @@ function gr_display(plt::Plot{GRBackend}, clear=true, update=true,
       GR.setwindow(-1, 1, -1, 1)
       rmin, rmax = GR.adjustrange(minimum(r), maximum(r))
       gr_polaraxes(rmin, rmax)
-      phi, r, = p[:x], p[:y]
+      phi, r = p[:x], p[:y]
       r = 0.5 * (r - rmin) / (rmax - rmin)
       n = length(r)
       x = zeros(n)


### PR DESCRIPTION
- needs further testing
- ``gr.jl`` 3D routines (internally) require 256 contiguous RGB24 color values (with color indexes ranging from 1000 to 1255)

@tbreloff : thanks in advance ...