### PR TITLE
add support for legend and label in pgfplots

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -780,7 +780,7 @@ function convertLegendValue(val::Symbol)
         :best
     elseif val in (:no, :none)
         :none
-    elseif val in (:right, :left, :top, :bottom, :inside, :best, :legend)
+    elseif val in (:right, :left, :top, :bottom, :inside, :best, :legend, :topright, :topleft, :bottomleft, :bottomright)
         val
     else
         error("Invalid symbol for legend: $val")

--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -10,9 +10,9 @@ supportedArgs(::PGFPlotsBackend) = [
      :fillalpha,
     # :foreground_color,
     # :group,
-    # :label,
+     :label,
     # :layout,
-    # :legend,
+     :legend,
      :seriescolor, :seriesalpha,
      :linecolor,
      :linestyle,
@@ -99,6 +99,17 @@ const _pgfplots_markers = KW(
     :pentagon => "mark = pentagon*,"
 )
 
+const _pgfplots_legend_pos = KW(
+    :right => "east",
+    :left => "west",
+    :top => "north",
+    :bottom => "south",
+    :bottomleft => "south west",
+    :bottomright => "south east",
+    :topright => "north east",
+    :topleft => "north west"
+)
+
 function _pgfplots_get_color(kwargs, symb)
     c = typeof(kwargs[symb]) == Symbol ? convertColor(kwargs[symb]) : kwargs[symb].c
     "{rgb,1:red,$(float(c.r));green,$(float(c.g));blue,$(float(c.b))}"
@@ -153,12 +164,20 @@ function _pgfplots_get_fill_color!(kwargs, plt)
     kwargs[:style] *= "fill opacity = $α,"
 end
 
+function _pgfplots_get_label!(kwargs, plt)
+    if plt[:label] != nothing && plt[:legend] != :none
+        kwargs[:legendentry] = plt[:label]
+    end
+end
+
+
 function _pgfplots_get_plot_kwargs(plt)
     kwargs = KW()
     kwargs[:style] = ""
     _pgfplots_get_linestyle!(kwargs, plt)
     _pgfplots_get_marker!(kwargs, plt)
     _pgfplots_get_series_color!(kwargs, plt)
+    _pgfplots_get_label!(kwargs, plt)
     kwargs
 end
 
@@ -324,6 +343,9 @@ function _pgfplots_get_axis_kwargs(d)
 
     end
 
+    if ((d[:legend] != :none) || (d[:legend] != :best)) && (d[:legend] in keys(_pgfplots_legend_pos))
+        axisargs[:legendPos] = _pgfplots_legend_pos[d[:legend]]
+    end
     axisargs
 end
 
@@ -331,7 +353,12 @@ end
 
 #################  This is the important method to implement!!! #################
 function _make_pgf_plot(plt::Plot{PGFPlotsBackend})
-    os = [_pgfplots_axis(plt_series) for plt_series in plt.seriesargs]
+    os = Any[]
+    # We need to send the :legend KW to the axis
+    for plt_series in plt.seriesargs
+        plt_series[:legend] = plt.plotargs[:legend]
+        push!(os, _pgfplots_axis(plt_series))
+    end
     axisargs  =_pgfplots_get_axis_kwargs(plt.plotargs)
     plt.o = PGFPlots.Axis([os...]; axisargs...)
 end

--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -1013,7 +1013,11 @@ const _pyplot_legend_pos = KW(
     :right => "right",
     :left => "center left",
     :top => "upper center",
-    :bottom => "lower center"
+    :bottom => "lower center",
+    :bottomleft => "lower left",
+    :bottomright => "lower right",
+    :topright => "upper right",
+    :topleft => "upper left"
   )
 
 # function addPyPlotLegend(plt::Plot)


### PR DESCRIPTION
also adds some extra kwargs for legend positions

Screenshots:

![image](https://cloud.githubusercontent.com/assets/1282691/15179761/12d29756-177e-11e6-850e-97a3058194bc.png)

And using a new kwarg for pyplot for example `:bottomright`

![image](https://cloud.githubusercontent.com/assets/1282691/15179778/290fc7d2-177e-11e6-81bb-202c97f3729a.png)

I literally opened the source code for `Plots` for the first time an hour ago so I might have missed stuff...

cc @pkofod 