### PR TITLE
Fix bug in some linecolors in PGFPlots

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -108,7 +108,12 @@ const _pgfplots_legend_pos = KW(
 
 function _pgfplots_get_color(kwargs, symb)
     c = typeof(kwargs[symb]) == Symbol ? convertColor(kwargs[symb]) : kwargs[symb].c
-    "{rgb,1:red,$(float(c.r));green,$(float(c.g));blue,$(float(c.b))}"
+    # We need to convert to decimals here because pgfplot will error
+    # for colors in engineering notation
+    r_str =  @sprintf("%.8f", float(c.r))
+    g_str =  @sprintf("%.8f", float(c.g))
+    b_str =  @sprintf("%.8f", float(c.b))
+    "{rgb,1:red,$(r_str);green,$(g_str);blue,$(b_str)}"
 end
 
 function _pgfplots_get_linestyle!(kwargs, plt)


### PR DESCRIPTION
For some linecolors the current PGFPlots wrapper generates something like this:

```tex
\addplot+ [solid,line width = 1 pt,mark = none,mark size = 3.0,mark options = {color={rgb,1:red,0.0;green,0.0;blue,0.0},fill={rgb,1:red,4.821181623260173e-7;green,0.665758981292356;blue,0.6809969518707948},fill opacity = 1.0,solid},color={rgb,1:red,4.821181623260173e-7;green,0.665758981292356;blue,0.6809969518707948},draw opacity = 1.0,]c
```

The problem here is that the line colors are given in engineering format (`4.8...e-7`). This errors for me with:

```
./error.tex:40: Illegal unit of measure (pt inserted). [\end{axis}]
./error.tex:40: Missing number, treated as zero. [\end{axis}]
./error.tex:40: Illegal unit of measure (pt inserted). [\end{axis}]
./error.tex:40: Arithmetic overflow. [\end{axis}]
./error.tex:40: Arithmetic overflow. [\end{axis}]
```

This PR solves this by converting to deciamals before sending it to pgfplots.

cc @pko
