### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -737,7 +737,7 @@ function _add_series(pkg::PyPlotBackend, plt::Plot, d::KW)
     end
 
     # this sets the bg color inside the grid
-    ax[:set_axis_bgcolor](getPyPlotColor(plt.plotargs[:background_color_inside]))
+    ax[:set_facecolor](getPyPlotColor(plt.plotargs[:background_color_inside]))
 
     # handle area filling
     fillrange = d[:fillrange]


### PR DESCRIPTION
Fix for the warning:
sys:1: MatplotlibDeprecationWarning: The set_axis_bgcolor function was deprecated in version 2.0. Use set_facecolor instead.