### PR TITLE
WIP: Adding support for arrays in violin-plot

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -69,7 +69,7 @@ function seriestype_supported(pkg::AbstractBackend, st::Symbol)
     if st in supported_types(pkg)
         return :native
     end
-    
+
     haskey(_series_recipe_deps, st) || return :no
 
     supported = true
@@ -341,7 +341,7 @@ end
 # ---------------------------------------------------------------------------
 # bezier curves
 
-# get the value of the curve point at position t 
+# get the value of the curve point at position t
 function bezier_value(pts::AVec, t::Real)
     val = 0.0
     n = length(pts)-1
@@ -719,23 +719,38 @@ end
 
     # create a list of shapes, where each shape is a single boxplot
     shapes = Shape[]
-    groupby = extractGroupArgs(d[:x])
 
-    for (i, glabel) in enumerate(groupby.groupLabels)
+    legend --> false
 
-        # get the edges and widths
-        y = d[:y][groupby.groupIds[i]]
-        widths, centers = violin_coords(y, trim=trim)
-
+    if length(d[:x])==1
+        widths, centers = violin_coords(d[:y], trim=trim)
         # normalize
         widths = _box_halfwidth * widths / maximum(widths)
 
         # make the violin
-        xcenter = discrete_value!(d[:subplot][:xaxis], glabel)[1]
+        xcenter = discrete_value!(d[:subplot][:xaxis], d[:x][1])[1]
         xcoords = vcat(widths, -reverse(widths)) + xcenter
         ycoords = vcat(centers, reverse(centers))
         push!(shapes, Shape(xcoords, ycoords))
+    else
+        groupby = extractGroupArgs(d[:x])
+        for (i, glabel) in enumerate(groupby.groupLabels)
+
+            # get the edges and widths
+            y = d[:y][groupby.groupIds[i]]
+            widths, centers = violin_coords(y, trim=trim)
+
+            # normalize
+            widths = _box_halfwidth * widths / maximum(widths)
+
+            # make the violin
+            xcenter = discrete_value!(d[:subplot][:xaxis], glabel)[1]
+            xcoords = vcat(widths, -reverse(widths)) + xcenter
+            ycoords = vcat(centers, reverse(centers))
+            push!(shapes, Shape(xcoords, ycoords))
+        end
     end
+
 
     # d[:plotarg_overrides] = KW(:xticks => (1:length(shapes), groupby.groupLabels))
     seriestype := :shape


### PR DESCRIPTION
Violin plots only work with `DataFrame`, see PR #310 for an example.

I use arrays and I would like to draw violins a locations `x` with distribution from samples in `s`.  Something like this would be the intuitive interface to me:
```
x = [1.0, 7.5, 9.0]
s = rand(100,length(x))
violin(x', s)
```
Which now gives:
![vio](https://cloud.githubusercontent.com/assets/4098145/16145667/28684106-347a-11e6-9af2-97e6f93f538b.png)

Any help appreciated in making the color not cycle.