### PR TITLE
Switch blue and violet in rainbow colour palette.

### DIFF
--- a/src/colors.jl
+++ b/src/colors.jl
@@ -78,7 +78,7 @@ end
 
 # --------------------------------------------------------------
 
-const _rainbowColors = [colorant"blue", colorant"purple", colorant"green", colorant"orange", colorant"red"]
+const _rainbowColors = [colorant"purple", colorant"blue", colorant"green", colorant"orange", colorant"red"]
 const _testColors = [colorant"darkblue", colorant"blueviolet",  colorant"darkcyan",colorant"green",
                      darken(colorant"yellow",0.3), colorant"orange", darken(colorant"red",0.2)]
 


### PR DESCRIPTION
Apologies for the PR from out of the blue (no pun intended).

The existing colour spread for the 'rainbow' palette seems slightly different to most other plotting tools.  In general, the sequence (from positive to negative) goes: red, orange, yellow, green, blue, purple/indigo/violet (perhaps inspired by the mnemonic referencing Richard of York).  Plots.jl, however, goes: red, orange, yellow, green, purple, blue.  I can't find any other colour palettes called 'rainbow' which use the order that Plots.jl does.  Hence this PR, which simply reverses the blue and purple, and produces plots which match most other software.

Although I admit this is a subjective decision, I would point to [some](https://en.wikipedia.org/wiki/Rainbow) [other](https://www.soest.hawaii.edu/gmt/gmt/html/GMT_Docs.html#x1-177000I.4) [sources](http://matplotlib.org/examples/color/colormaps_reference.html) to back me up on this.  Using Plots with the existing colour scale for 'rainbow' also made me realise how used I am to the scale proposed here.

Of course, if you decide to stick with the status quo, then fair enough.