### PR TITLE
Legend location in subplot

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -809,6 +809,7 @@ function convertLegendValue(val::Symbol)
 end
 convertLegendValue(val::Bool) = val ? :best : :none
 convertLegendValue(val::Void) = :none
+convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
@tbreloff This works for me but I have no idea if it impacts other parts of the code base!?!

```
using Plots
pgfplots()
plot(rand(10, 4), layout=4, legend=[:none :topright :bottomleft :bottomright])
```
![legendlayout](https://cloud.githubusercontent.com/assets/8177701/16756074/a25068c8-4856-11e6-8f68-bcc1dd7f7057.png)

