### PR TITLE
Add eps to savefig

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -36,6 +36,13 @@ function ps(plt::Plot, fn::AbstractString)
 end
 ps(fn::AbstractString) = ps(current(), fn)
 
+function eps(plt::Plot, fn::AbstractString)
+  fn = addExtension(fn, "eps")
+  io = open(fn, "w")
+  writemime(io, MIME("image/eps"), plt)
+  close(io)
+end
+eps(fn::AbstractString) = eps(current(), fn)
 
 function tex(plt::Plot, fn::AbstractString)
   fn = addExtension(fn, "tex")
@@ -54,6 +61,7 @@ const _savemap = Dict(
     "svg" => svg,
     "pdf" => pdf,
     "ps"  => ps,
+    "eps" => eps,
     "tex" => tex,
   )
 


### PR DESCRIPTION
This adds EPS support to `savefig`. 

Maybe I've just misunderstood, but it doesn't seem like this is supported.
Currently, the following does not create an eps image:
```j
plt=plot(cos,0,1)
savefig(plt, "test.eps")
```
Instead it creates a png file "test.eps.png". 
