### PR TITLE
Remove unnecessary `_print` extension

### DIFF
--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -57,7 +57,6 @@ const _plotly_js_path = joinpath(dirname(@__FILE__), "..", "..", "deps", "plotly
 function _initialize_backend(::PlotlyBackend; kw...)
   @eval begin
     import JSON
-    JSON._print(io::IO, state::JSON.State, dt::Union{Date,DateTime}) = print(io, '"', dt, '"')
 
     _js_code = open(readstring, _plotly_js_path, "r")
 


### PR DESCRIPTION
Since JSON v0.5.1 (https://github.com/JuliaLang/JSON.jl/pull/138), all subtypes of `TimeType` are already serialized the way defined here, so this line is unnecessary. Starting JSON v0.7.0, it will cause a deprecation warning.