### PR TITLE
[RFC] Prepared object

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -333,3 +333,9 @@ function _display(plt::Plot{PGFPlotsBackend})
     # cleanup
     PGFPlots.cleanup(plt.o)
 end
+
+function prepared_object(plt::Plot{PGFPlotsBackend})
+    prepare_output(plt)
+    _make_pgf_plot!(plt)
+    plt.o
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -251,11 +251,6 @@ function prepare_output(plt::Plot)
     _update_plot_object(plt)
 end
 
-function prepared_object(plt::Plot)
-    prepare_output(plt)
-    plt.o
-end
-
 # --------------------------------------------------------------------
 # plot to a Subplot
 


### PR DESCRIPTION
The fix for #267 doesn't seem to work to populate the `.o`. In the case of `PGFPlots` the `plt.o` seems to be populated in the `_make_pgf_plot!` function, which in turn is used by the `_display` function for the specific backend. Thus it is not enough to run `prepare_output` to populate the `plt.o` object.

In this PR the `prepared_object` function (which returns the plt.o object) is moved into the respective backend file. Only implemented for pgfplots so far.

Is this the way to do it? If so, I will update for the other backends as well.