### PR TITLE
stop double adding style options to the axis in pgfplots

### DIFF
--- a/src/backends/pgfplots.jl
+++ b/src/backends/pgfplots.jl
@@ -254,9 +254,6 @@ function _update_plot_object(plt::Plot{PGFPlotsBackend})
                 axisstyle, axiskw = pgf_axis(sp, letter)
                 append!(style, axisstyle)
                 merge!(kw, axiskw)
-                for sty in axisstyle
-                    push!(style, sty)
-                end
             end
         end
 


### PR DESCRIPTION
The `append!` already appends the `axisstyle` to `style` so there is no need for the loop after. This caused for me double `xticks` and `xtickslabel` options in the .tex file (which is harmless but unnecessary).

cc @pkofod 