### PR TITLE
mimewritable should be true only if the original object supports it

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -172,6 +172,7 @@ for mime in keys(_mimeformats)
     end
 end
 
+Base.mimewritable{B}(m::MIME, plt::Plot{B}) = mimewritable(m, plt.o)
 
 # ---------------------------------------------------------
 # A backup, if no PNG generation is defined, is to try to make a PDF and use FileIO to convert


### PR DESCRIPTION
Allows PlotlyJS (and possibly other backends) to work with Interact.

I'm not sure why `_show(::IO, ::MIME"image/svg+xml" (or png), ::Plot{PlotlyJSBackend})` just hangs for me.