### PR TITLE
Fix for dpi in pyplot backend

### DIFF
--- a/src/backends/pyplot.jl
+++ b/src/backends/pyplot.jl
@@ -356,7 +356,7 @@ function py_bbox_title(ax)
 end
 
 function py_dpi_scale(plt::Plot{PyPlotBackend}, ptsz)
-    ptsz * DPI / plt[:dpi]
+    ptsz * plt[:dpi] / DPI
 end
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A simple fix for dpi configuration in pyplot backend.  Easy to check that it should be like this when using, for example GtkAgg backend for matlpotlib.  Very useful on hidpi monitor.