### PR TITLE
Remove precompilation

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,6 +1,4 @@
 
-__precompile__()
-
 module Plots
 
 using Reexport


### PR DESCRIPTION
Precompilation has never played nice with Plots, but now it has gotten even worse. Getting rid of precompilation fixes #543 and likely other issues. In normal use cases, the vast majority of time to plot comes from importing the other plotting libraries, so I did not notice a significant performance loss. Thus I see upsides without a downside, at least until conditional modules are a thing.
