### PR TITLE
Fix markerstrokecolor match

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -1221,7 +1221,7 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
 
     # update markerstrokecolor
     d[:markerstrokecolor] = if d[:markerstrokecolor] == :match
-        plot_color(sp[:seriescolor], d[:markerstrokealpha])
+        plot_color(d[:seriescolor], d[:markerstrokealpha])
     else
         getSeriesRGBColor(d[:markerstrokecolor], d[:markerstrokealpha], sp, plotIndex)
     end

--- a/src/args.jl
+++ b/src/args.jl
@@ -1221,7 +1221,7 @@ function _add_defaults!(d::KW, plt::Plot, sp::Subplot, commandIndex::Int)
 
     # update markerstrokecolor
     d[:markerstrokecolor] = if d[:markerstrokecolor] == :match
-        plot_color(sp[:foreground_color_subplot], d[:markerstrokealpha])
+        plot_color(sp[:seriescolor], d[:markerstrokealpha])
     else
         getSeriesRGBColor(d[:markerstrokecolor], d[:markerstrokealpha], sp, plotIndex)
     end


### PR DESCRIPTION
Makes `markerstrokecolor` value `:match` default to `seriescolor` as specified in the docs (current setting `foreground_color_subplot`)