### PR TITLE
Implemented legend position in plotly

### DIFF
--- a/src/args.jl
+++ b/src/args.jl
@@ -857,6 +857,7 @@ function convertLegendValue(val::Symbol)
 end
 convertLegendValue(val::Bool) = val ? :best : :none
 convertLegendValue(val::Void) = :none
+convertLegendValue{S<:Real, T<:Real}(v::Tuple{S,T}) = v
 convertLegendValue(v::AbstractArray) = map(convertLegendValue, v)
 
 # -----------------------------------------------------------------------------

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -93,6 +93,20 @@ end
 
 # ----------------------------------------------------------------
 
+const _plotly_legend_pos = KW(
+    :right => [1., 0.5],
+    :left => [0., 0.5],
+    :top => [0.5, 1.],
+    :bottom => [0.5, 0.],
+    :bottomleft => [0., 0.],
+    :bottomright => [1., 0.],
+    :topright => [1., 1.],
+    :topleft => [0., 1.]
+    )
+
+plotly_legend_pos(pos::Symbol) = get(_plotly_legend_pos, pos, [1.,1.])
+plotly_legend_pos{S<:Real, T<:Real}(v::Tuple{S,T}) = v
+
 function plotly_font(font::Font, color = font.color)
     KW(
         :family => font.family,
@@ -100,6 +114,7 @@ function plotly_font(font::Font, color = font.color)
         :color  => rgba_string(color),
     )
 end
+
 
 function plotly_annotation_dict(x, y, val; xref="paper", yref="paper")
     KW(
@@ -293,11 +308,14 @@ function plotly_layout(plt::Plot)
 
         # legend
         d_out[:showlegend] = sp[:legend] != :none
+        xpos,ypos = plotly_legend_pos(sp[:legend])
         if sp[:legend] != :none
             d_out[:legend] = KW(
                 :bgcolor  => rgba_string(sp[:background_color_legend]),
                 :bordercolor => rgba_string(sp[:foreground_color_legend]),
                 :font     => plotly_font(sp[:legendfont], sp[:foreground_color_legend]),
+                :x => xpos,
+                :y => ypos
             )
         end
 


### PR DESCRIPTION
I've added a way to change the position of the legend in plotlyjs backend (see #574 ). One can either use the keywords:

<img width="633" alt="screenshot 2016-11-20 15 46 42" src="https://cloud.githubusercontent.com/assets/6333339/20464080/a88a0f16-af38-11e6-9ad7-cfa13097d918.png">

Or input coordinates as a tuple:

<img width="636" alt="screenshot 2016-11-20 15 50 12" src="https://cloud.githubusercontent.com/assets/6333339/20464098/0d4cbfde-af39-11e6-96f8-082a6aaff592.png">
