### PR TITLE
Allow errorbars in plots with categorical x axis (see #549 )

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -526,8 +526,7 @@ end
 
 function error_coords(xorig, yorig, ebar)
     # init empty x/y, and zip errors if passed Tuple{Vector,Vector}
-    x, y = zeros(0), zeros(0)
-
+    x, y = Array(float_extended_type(xorig), 0), Array(Float64, 0)
     # for each point, create a line segment from the bottom to the top of the errorbar
     for i = 1:max(length(xorig), length(yorig))
         xi = cycle(xorig, i)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -228,6 +228,12 @@ function Base.next(itr::SegmentsIterator, nextidx::Int)
     istart:iend, i
 end
 
+# Find minimal type that can contain NaN and x
+# To allow use of NaN separated segments with categorical x axis
+
+float_extended_type{T}(x::AbstractArray{T}) = Union{T,Float64}
+float_extended_type{T<:Real}(x::AbstractArray{T}) = Float64
+
 # ------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
 As mentioned in #549 , it is impossible to add errorbars to a plot if the x axis is categorical. This is simply because Plots.jl uses NaN separated segments to do that and it can't mix NaN with the x-values for a categorical x. This change expands the element-type of the x-axis to allow appending NaNs and now  having categorical variables doesn't create problems anymore:

<img width="633" alt="screenshot 2016-11-26 02 10 18" src="https://cloud.githubusercontent.com/assets/6333339/20637363/81ddb914-b37d-11e6-9496-e34d9b5aa7e2.png">

