### PR TITLE
Added savefig html

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -52,6 +52,14 @@ function tex(plt::Plot, fn::AbstractString)
 end
 tex(fn::AbstractString) = tex(current(), fn)
 
+function html(plt::Plot, fn::AbstractString)
+    fn = addExtension(fn, "html")
+    io = open(fn, "w")
+    show(io, MIME("text/html"), plt)
+    close(io)
+end
+html(fn::AbstractString) = html(current(), fn)
+
 
 # ----------------------------------------------------------------
 
@@ -63,6 +71,7 @@ const _savemap = Dict(
     "ps"  => ps,
     "eps" => eps,
     "tex" => tex,
+    "html" => html,
   )
 
 function getExtension(fn::AbstractString)


### PR DESCRIPTION
I've added the option to save the plot in html using savefig. I think it's particularly useful for the plotlyjs backend because:
a) It preserves interactivity
b) In the jupyter notebook it seems that the only format to save plotlyjs plots reliably is html (see [#88](https://github.com/spencerlyon2/PlotlyJS.jl/issues/88) )