### PR TITLE
buildanimation: mov and mp4

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -80,6 +80,8 @@ export
     Animation,
     frame,
     gif,
+    mov,
+    mp4,
     animate,
     @animate,
     @gif,


### PR DESCRIPTION
I really need to get in the habit of PRing my changes.  This one adds animation outputs for `mov` and `mp4` files.  Call gif/mov/mp4 with an `Animation`, or now you can call `buildanimation` directly with a directory of png files and output file: `Plots.buildanimation.("/tmp/tmp1tgowO/", "/tmp/tmp.mp4")`