### PR TITLE
Fix precompile disable

### DIFF
--- a/src/Plots.jl
+++ b/src/Plots.jl
@@ -1,3 +1,4 @@
+__precompile__(false)
 
 module Plots
 


### PR DESCRIPTION
So I put in a PR more than a month ago disabling precompilation because of the conditional dependency problems which was causing problems with Plots.jl's interactions with other packages (and making it not work on v0.6 completely).

However, I did it wrong. Instead of disabling precompilation by deleting the `__precompile__()` line, you need to change it to `__precompile__(false)`. I tracked down a user's issue to a faulty precompilation cache  in a no longer precompiling package a few days ago, and opened this issue only to learn about this:

https://github.com/JuliaLang/julia/issues/19557

If users have ran into some weird issues with precompilation caches, this will fix that issue.