### PR TITLE
Use `sans-serif` as default font family (fix #593)

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -248,7 +248,7 @@ end
 function font(args...)
 
   # defaults
-  family = "Helvetica"
+  family = "sans-serif"
   pointsize = 14
   halign = :hcenter
   valign = :vcenter


### PR DESCRIPTION
Rather than specifying a specific typeface, set the font
*family* in the `family` field of `Font` as `sans-serif`
by default.

Fixes #593.