### PR TITLE
Fix save as .tex for PGFPlots

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -52,6 +52,11 @@ function tex(plt::Plot, fn::AbstractString)
 end
 tex(fn::AbstractString) = tex(current(), fn)
 
+function tex(plt::Plot{PGFPlotsBackend}, fn::AbstractString)
+  fn = addExtension(fn, "tex")
+  PGFPlots.save(fn, backend_object(plt), include_preamble=false)
+end
+
 function html(plt::Plot, fn::AbstractString)
     fn = addExtension(fn, "html")
     io = open(fn, "w")


### PR DESCRIPTION
From @KristofferC's suggestion [here](https://github.com/tbreloff/Plots.jl/issues/637). I don't actually know if this approach breaks things for other backends or not, so have a look.