### PR TITLE
WIP: adding surfacecolor attribute in surface

### DIFF
--- a/src/arg_desc.jl
+++ b/src/arg_desc.jl
@@ -29,6 +29,7 @@ const _arg_desc = KW(
 :z                 	=> "Various. Input data. Third Dimension. May be wrapped by a `Surface` for surface and heatmap types.",
 :marker_z          	=> "AbstractVector, Function `f(x,y,z) -> z_value`, or nothing. z-values for each series data point, which correspond to the color to be used from a markercolor gradient.",
 :line_z          	=> "AbstractVector, Function `f(x,y,z) -> z_value`, or nothing. z-values for each series line segment, which correspond to the color to be used from a linecolor gradient.  Note that for N points, only the first N-1 values are used (one per line-segment).",
+:surfacecolor           => "Matrix{Float64} of the same size as z matrix, which specifies the color of the 3D surface; the default value is `nothing`.",
 :levels            	=> "Integer, NTuple{2,Integer}. Number of levels (or x-levels/y-levels) for a contour type.",
 :orientation       	=> "Symbol.  Horizontal or vertical orientation for bar types.  Values `:h`, `:hor`, `:horizontal` correspond to horizontal (sideways, anchored to y-axis), and `:v`, `:vert`, and `:vertical` correspond to vertical (the default).",
 :bar_position      	=> "Symbol.  Choose from `:overlay` (default), `:stack`.  (warning: May not be implemented fully)",

--- a/src/args.jl
+++ b/src/args.jl
@@ -189,6 +189,7 @@ const _series_defaults = KW(
     :marker_z          => nothing,   # value for color scale
     :line_z            => nothing,
     :levels            => 15,
+    :surfacecolor      => nothing,
     :orientation       => :vertical,
     :bar_position      => :overlay,  # for bar plots and histograms: could also be stack (stack up) or dodge (side by side)
     :bar_width         => nothing,
@@ -431,6 +432,7 @@ add_aliases(:zguide, :zlabel, :zlab, :zl)
 add_aliases(:zlims, :zlim, :zlimit, :zlimits)
 add_aliases(:zticks, :ztick)
 add_aliases(:zrotation, :zrot, :zr)
+add_aliases(:surfacecolor, :surfacecolour, :sc, :surfcolor, :surfcolour)
 add_aliases(:legend, :leg, :key)
 add_aliases(:colorbar, :cb, :cbar, :colorkey)
 add_aliases(:clims, :clim, :cbarlims, :cbar_lims, :climits, :color_limits)

--- a/src/backends/plotly.jl
+++ b/src/backends/plotly.jl
@@ -20,7 +20,7 @@ const _plotly_attr = merge_with_base_supported([
     :guide, :lims, :ticks, :scale, :flip, :rotation,
     :tickfont, :guidefont, :legendfont,
     :grid, :legend, :colorbar,
-    :marker_z, :levels,
+    :marker_z, :surfacecolor, :levels,
     :ribbon, :quiver,
     :orientation,
     # :overwrite_figure,
@@ -432,7 +432,7 @@ function plotly_series(plt::Plot, series::Series)
 
     # for surface types, set the data
     if st in (:heatmap, :contour, :surface, :wireframe)
-        for letter in [:x,:y,:z]
+        for letter in [:x,:y,:z,:surfacecolor]
             d_out[letter] = plotly_surface_data(series, series[letter])
         end
     end

--- a/test/surfacetest.jl
+++ b/test/surfacetest.jl
@@ -1,4 +1,6 @@
 module SurfacePlotsTests
+using Plots
+plotlyjs();
 m=32; n=5;
 r = (0:m)/m
 theta = reshape(pi*(-n*m:n*m)/m, 1, 2*n*m+1)

--- a/test/surfacetest.jl
+++ b/test/surfacetest.jl
@@ -1,0 +1,12 @@
+module SurfacePlotsTests
+m=32; n=5;
+r = (0:m)/m
+theta = reshape(pi*(-n*m:n*m)/m, 1, 2*n*m+1)
+z = r * exp(im*theta)
+s = r.^(1/n) * exp(im*theta/n)
+x = real(z)
+y = imag(z)
+u = real(s)
+v = imag(s)
+surface(x,y,u,surfacecolor=randn(size(v)))
+end


### PR DESCRIPTION
This is my attempt to add ```surfacecolor``` attribute in the ```surface``` function of ```Plots.jl``` using ```PlotlyJS``` as its backend. At least, specifying the ```surfacecolor``` attribute in the ```surface``` function does not throw error or warning message at this point, but the way I modified ```backend/plotly.jl``` is still wrong. I also added ```test/surfacetest.jl```, but it does not plot anything somehow. If I copy the main body of that test to my julia REPL session, it generates a surface plot with still a wrong color on it. I would greatly appreciate your help to complete this task.

Just in case, if one runs the following segment without ```using Plots```, but with ```using PlotlyJS```, it works, and I want to do the same with ```using Plots```.

```julia
using PlotlyJS
m=32; n=5;
r = (0:m)/m
theta = reshape(pi*(-n*m:n*m)/m, 1, 2*n*m+1)
z = r * exp(im*theta)
s = r.^(1/n) * exp(im*theta/n)
x = real(z)
y = imag(z)
u = real(s)
v = imag(s)
surface(x=x,y=y,z=u,surfacecolor=randn(size(v)))
```
